### PR TITLE
Fix error regarding to extremely long note

### DIFF
--- a/plugins/notes.py
+++ b/plugins/notes.py
@@ -141,14 +141,14 @@ def ReadLengthField(blob):
     skip = 0
     try:
         data_length = int(struct.unpack('<B', blob[0])[0])
-        if data_length > 0x7F: # -ve number for signed byte
-            skip = 2
-            length = (int(struct.unpack('<B', blob[1])[0]) << 7) + (data_length & 0x7F)
-        else:
-            skip = 1
-            length = data_length
+        length = data_length & 0x7F
+        while data_length > 0x7F:
+            skip += 1
+            data_length = int(struct.unpack('<B', blob[skip])[0])
+            length = ((data_length & 0x7F) << (skip * 7)) + length
     except:
-        log.exception('Error trying to read length field in note data blob')    
+        log.exception('Error trying to read length field in note data blob')
+    skip += 1
     return length, skip
 
 def ProcessNoteBodyBlob(blob):


### PR DESCRIPTION
The length field could be longer than 2 bytes. Previously, only 2 bytes would be read, hence the length was wrong, and there was an offset in the skip value, causing errors/exceptions. This CL supports reading those length fields longer than 2 bytes in case of reading extremely long notes.

NOTES: I'm not very familiar with Apple's data structure regarding the Notes app, so please do point out if I've made any mistakes in this PR. But I have met this situation on my Mac (10.13.4), and the fix is tested to be working on my end.

---
real example in my db:
```
\x08\x00\x12\x9a\xc6\x01\x08\x00\x10\x00\x1a\x92\xc6\x01\x12...
```
in which, `\x9a\xc6\x01` is 3 bytes.