### PR TITLE
Rise the number of file descriptors to 2048 to prevent "too many open files" error

### DIFF
--- a/mac_apt.py
+++ b/mac_apt.py
@@ -28,7 +28,6 @@ import sys
 import textwrap
 import time
 import traceback
-import platform
 from plugins.helpers.aff4_helper import EvidenceImageStream
 from plugins.helpers.apfs_reader import ApfsContainer, ApfsDbInfo
 from plugins.helpers.apple_sparse_image import AppleSparseImage
@@ -463,28 +462,6 @@ log.info("Started {}, version {}".format(__PROGRAMNAME, __VERSION))
 log.info("Dates and times are in UTC unless the specific artifact being parsed saves it as local time!")
 log.debug(' '.join(sys.argv))
 LogLibraryVersions(log)
-
-# Set the limit of file descriptors
-new_limit = 2048
-if platform.system() == 'Windows':
-    import ctypes
-    if ctypes.cdll.msvcrt._getmaxstdio() < new_limit:
-        log.debug('Current the maximum number of file handlers: {}'.format(ctypes.cdll.msvcrt._getmaxstdio()))
-        if ctypes.cdll.msvcrt._setmaxstdio(new_limit) < 0:
-            Exit('Cannot set the maximum number of file handlers.')
-        log.debug('Set the maximum number of file handlers: {}'.format(new_limit))
-elif platform.system() in ('Linux', 'Darwin'):
-    import resource
-    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    log.debug('Current file descriptor limit: Soft Limit = {}, Hard Limit = {}'.format(soft_limit, hard_limit))
-    if soft_limit < new_limit:
-        try:
-            resource.setrlimit(resource.RLIMIT_NOFILE, (new_limit, hard_limit))
-            log.debug('Set file descriptor limit: Soft Limit = {}, Hard Limit = {}'.format(new_limit, hard_limit))
-        except ValueError as err:
-            Exit('Cannot set file descriptor limit.')
-else:
-    Exit('Cannot determine the platform system.')
 
 # Check inputs
 if not CheckInputType(args.input_type): 

--- a/mac_apt.py
+++ b/mac_apt.py
@@ -28,6 +28,7 @@ import sys
 import textwrap
 import time
 import traceback
+import platform
 from plugins.helpers.aff4_helper import EvidenceImageStream
 from plugins.helpers.apfs_reader import ApfsContainer, ApfsDbInfo
 from plugins.helpers.apple_sparse_image import AppleSparseImage
@@ -462,6 +463,28 @@ log.info("Started {}, version {}".format(__PROGRAMNAME, __VERSION))
 log.info("Dates and times are in UTC unless the specific artifact being parsed saves it as local time!")
 log.debug(' '.join(sys.argv))
 LogLibraryVersions(log)
+
+# Set the limit of file descriptors
+new_limit = 2048
+if platform.system() == 'Windows':
+    import ctypes
+    if ctypes.cdll.msvcrt._getmaxstdio() < new_limit:
+        log.debug('Current the maximum number of file handlers: {}'.format(ctypes.cdll.msvcrt._getmaxstdio()))
+        if ctypes.cdll.msvcrt._setmaxstdio(new_limit) < 0:
+            Exit('Cannot set the maximum number of file handlers.')
+        log.debug('Set the maximum number of file handlers: {}'.format(new_limit))
+elif platform.system() in ('Linux', 'Darwin'):
+    import resource
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    log.debug('Current file descriptor limit: Soft Limit = {}, Hard Limit = {}'.format(soft_limit, hard_limit))
+    if soft_limit < new_limit:
+        try:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (new_limit, hard_limit))
+            log.debug('Set file descriptor limit: Soft Limit = {}, Hard Limit = {}'.format(new_limit, hard_limit))
+        except ValueError as err:
+            Exit('Cannot set file descriptor limit.')
+else:
+    Exit('Cannot determine OS.')
 
 # Check inputs
 if not CheckInputType(args.input_type): 

--- a/mac_apt.py
+++ b/mac_apt.py
@@ -484,7 +484,7 @@ elif platform.system() in ('Linux', 'Darwin'):
         except ValueError as err:
             Exit('Cannot set file descriptor limit.')
 else:
-    Exit('Cannot determine OS.')
+    Exit('Cannot determine the platform system.')
 
 # Check inputs
 if not CheckInputType(args.input_type): 


### PR DESCRIPTION
The UNIFIEDLOGS plugin sometimes consume more than 256 file descriptors.
This can be a problem like below since the default number of file descriptors in macOS is 256.

```
2021-07-28 17:06:59|MAIN.UNIFIED_LOG_READER_LIB|ERROR|Failed to open file /Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/31/5F89C905DA39B0A3209C69B946C0E0
Traceback (most recent call last):
  File "/Users/macforensics/Documents/GitHub/forked/mac_apt/plugins/helpers/UnifiedLog/virtual_file.py", line 30, in open
OSError: [Errno 24] Too many open files: '/Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/31/5F89C905DA39B0A3209C69B946C0E0'
2021-07-28 17:06:59|MAIN.UNIFIED_LOG_READER_LIB|ERROR|Failed to open file /Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/F0/8237E1BFB93D2093CA512883B5D251
Traceback (most recent call last):
  File "/Users/macforensics/Documents/GitHub/forked/mac_apt/plugins/helpers/UnifiedLog/virtual_file.py", line 30, in open
OSError: [Errno 24] Too many open files: '/Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/F0/8237E1BFB93D2093CA512883B5D251'
2021-07-28 17:06:59|MAIN.UNIFIED_LOG_READER_LIB|ERROR|Failed to open file /Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/C6/DF4A8A56FA339C9A33E282CA6594C6
Traceback (most recent call last):
  File "/Users/macforensics/Documents/GitHub/forked/mac_apt/plugins/helpers/UnifiedLog/virtual_file.py", line 30, in open
OSError: [Errno 24] Too many open files: '/Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/C6/DF4A8A56FA339C9A33E282CA6594C6'
2021-07-28 17:06:59|MAIN.UNIFIED_LOG_READER_LIB|ERROR|Failed to open file /Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/DC/21B720D5E03667B1F5CE474ABE72AF
Traceback (most recent call last):
  File "/Users/macforensics/Documents/GitHub/forked/mac_apt/plugins/helpers/UnifiedLog/virtual_file.py", line 30, in open
OSError: [Errno 24] Too many open files: '/Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/DC/21B720D5E03667B1F5CE474ABE72AF'
2021-07-28 17:06:59|MAIN.UNIFIED_LOG_READER_LIB|ERROR|Failed to open file /Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/87/94BC277F333231951FCC84D37377D1
Traceback (most recent call last):
  File "/Users/macforensics/Documents/GitHub/forked/mac_apt/plugins/helpers/UnifiedLog/virtual_file.py", line 30, in open
OSError: [Errno 24] Too many open files: '/Users/macforensics/Documents/GitHub/forked/mac_apt_out/20210728_01/Export/UNIFIEDLOGS/uuidtext/87/94BC277F333231951FCC84D37377D1'
```
