### PR TITLE
fixed several tiny bugs

### DIFF
--- a/plugins/autostart.py
+++ b/plugins/autostart.py
@@ -8,11 +8,13 @@
 '''
 
 import logging
-import nska_deserialize as nd
 import os
 import posixpath
-from plugins.helpers.bookmark import *
+
+import nska_deserialize as nd
 from plistutils.alias import AliasParser
+
+from plugins.helpers.bookmark import *
 from plugins.helpers.macinfo import *
 from plugins.helpers.writer import *
 
@@ -149,7 +151,7 @@ def process_kernel_extensions(mac_info, path, persistent_programs):
         for folder in folder_list:
             full_name = folder['name']
             full_path = path + '/' + full_name
-            
+
             name = os.path.splitext(full_name)[0] # removes extension (.kext or .plugin or .bundle usually)
             valid_source = full_path
             info_plist_path = full_path + '/Contents/Info.plist'
@@ -160,7 +162,7 @@ def process_kernel_extensions(mac_info, path, persistent_programs):
                     name = plist.get('CFBundleName', name)
                     name = name.lstrip('"').rstrip('"')
                 else:
-                    log.error("Problem reading plist for {} - ".format(info_plist_path, error))
+                    log.error("Problem reading plist for {} - {}".format(info_plist_path, error))
                 mac_info.ExportFile(info_plist_path, __Plugin_Name, "kext_" + name + "_", False)
             program = PersistentProgram(valid_source, name, full_name, 'Kernel Extension', 'root', 0, '', '')
             persistent_programs.append(program)
@@ -223,7 +225,7 @@ def get_run_when(plist, method):
     run_when = []
     run_at_load = plist.get('RunAtLoad', None)
     if run_at_load == True:
-        #run_when.append('RunAtLoad') # if run_at_load else '') # 'DontRunAtLoad' 
+        #run_when.append('RunAtLoad') # if run_at_load else '') # 'DontRunAtLoad'
         #For daemons this means execution at boot time, for agents execution at login.
         if method == 'Daemon':
             run_when.append('Run at Boot')
@@ -233,7 +235,7 @@ def get_run_when(plist, method):
         if plist.get(item, ''):
             run_when.append(item)
     return ', '.join(run_when)
-    
+
 def process_file(mac_info, file_path, persistent_programs, file_name):
     full_path = file_path + '/' + file_name
     mac_info.ExportFile(full_path, __Plugin_Name, '', False)
@@ -258,7 +260,7 @@ def process_overrides(mac_info, file_path, user, uid, persistent_programs):
         log.error("Problem reading plist - " + error)
 
 def ProcessLoginRestartApps(mac_info, persistent_programs):
-    '''Gets apps/windows set to relaunch upon re-login (after logout)''' 
+    '''Gets apps/windows set to relaunch upon re-login (after logout)'''
     processed_paths = set()
     plist_folder_path = '{}/Library/Preferences/ByHost' # /com.apple.loginwindow.<UUID>.plist'
 
@@ -311,7 +313,7 @@ def Plugin_Start(mac_info):
     persistent_usr_paths = {'Agents' : ['/Library/LaunchAgents'] }
     processed_paths = set()
     persistent_programs = []
-    
+
     ### process kernel extensions ###
     for path in kext_paths:
         process_kernel_extensions(mac_info, path, persistent_programs)
@@ -331,7 +333,7 @@ def Plugin_Start(mac_info):
             if mac_info.IsValidFilePath(file_path + '/' + file_name):
                 processed_paths.add(file_name)
                 process_file(mac_info, file_path, persistent_programs, file_name)
-    
+
     ### process user dirs ###
     for user in mac_info.users:
         user_name = user.user_name
@@ -346,7 +348,7 @@ def Plugin_Start(mac_info):
                     process_dir(mac_info, full_path, persistent_programs, method, user_name, user.UID)
                 else:
                     log.debug("Folder not found {}".format(full_path))
-        
+
         # process loginitems plist
         loginitems_plist_path = '{}/Library/Preferences/com.apple.loginitems.plist'.format(user.home_dir)
         if mac_info.IsValidFilePath(loginitems_plist_path) and mac_info.GetFileSize(loginitems_plist_path) > 70:

--- a/plugins/spotlightshortcuts.py
+++ b/plugins/spotlightshortcuts.py
@@ -4,7 +4,6 @@
    This file is part of mac_apt (macOS Artifact Parsing Tool).
    Usage or distribution of this software/code is subject to the 
    terms of the MIT License.
-   
 '''
 
 import logging
@@ -15,7 +14,7 @@ from plugins.helpers.writer import *
 
 __Plugin_Name = "SPOTLIGHTSHORTCUTS"
 __Plugin_Friendly_Name = "Spotlight shortcuts"
-__Plugin_Version = "1.0"
+__Plugin_Version = "1.1"
 __Plugin_Description = "Gets user typed data in the spotlight bar, used to launch applications and documents"
 __Plugin_Author = "Yogesh Khatri"
 __Plugin_Author_Email = "yogesh@swiftforensics.com"
@@ -33,7 +32,7 @@ def PrintAll(shortcut_items, output_params, source_path):
                    ]
     log.debug('Writing {} spotlight shortcut item(s)'.format(len(shortcut_items)))
     WriteList("spotlight shortcut information", "SpotlightShortcuts", shortcut_items, shortcut_info, output_params, source_path)
-    
+
 def ParseShortcutFile(input_file, shortcuts):
     success, plist, error = CommonFunctions.ReadPlist(input_file)
     if success:
@@ -54,7 +53,7 @@ def ReadSingleShortcutEntry(entry, value, shortcuts, uses_path, source, user):
         else:
             log.info("Found unknown item - {}, value={} in plist".format(item, value))
     shortcuts.append(sc)
-    
+
 
 def ReadShortcutPlist(plist, shortcuts, source='', user=''):
     try:
@@ -67,7 +66,7 @@ def ReadShortcutPlist(plist, shortcuts, source='', user=''):
                 ReadSingleShortcutEntry(item, value, shortcuts, False, source, user)
     except ValueError as ex:
         log.exception('Error reading plist')
-    
+
 def Plugin_Start(mac_info):
     '''Main Entry point function for plugin'''
     shortcuts = []
@@ -78,9 +77,9 @@ def Plugin_Start(mac_info):
             user_plist_rel_path = '{}/Library/Application Support/com.apple.spotlight.Shortcuts'
         elif version['minor'] >= 15:
             user_plist_rel_path = '{}/Library/Application Support/com.apple.spotlight/com.apple.spotlight.Shortcuts'
-    elif version['major'] == 11:
+    elif version['major'] >= 11:
         user_plist_rel_path = '{}/Library/Application Support/com.apple.spotlight/com.apple.spotlight.Shortcuts.v3'
-    
+
     processed_paths = set()
     for user in mac_info.users:
         user_name = user.user_name


### PR DESCRIPTION
# autostart.py
Fixed a message format of log.error().

# macinfo.py
Added process to normalize dest_rel_path with os.paht.normpath()
macOS 12 has a symlinked plist in LaunchAgents by default which has "//" in its target path like below.
So, I think we need to accept symbolic link files with such target paths.
```
% ls -al /System/Library/LaunchAgents/com.apple.webinspectord.plist  
lrwxr-xr-x  1 root  wheel  121  7 14 17:48 /System/Library/LaunchAgents/com.apple.webinspectord.plist -> ../../../Library/Apple/System/Library/CoreServices/SafariSupport.bundle/Contents/Resources//com.apple.webinspectord.plist
```

# quicklook.py
The columns of thumbnails table in index.sqlite have been changed in macOS 12 like below.

macOS 11.6.6
![スクリーンショット 2022-07-27 14 05 46](https://user-images.githubusercontent.com/26597618/181168613-5d8bf6a4-d31f-44e2-ad9f-d17ca7899014.png)

macOS 12.5
![スクリーンショット 2022-07-27 14 05 10](https://user-images.githubusercontent.com/26597618/181168657-dbd6d03a-1644-49de-889e-df866dfc6908.png)

bitmapFormat contains the same data as bitspercomponent, bitsperpixel, and bytesperrow with bplist format.

# spotlightshortcuts.py
Made compatible with macOS 12.