### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9
+
+RUN pip install anytree biplist construct==2.9.45 xlsxwriter plistutils kaitaistruct lz4 pytsk3==20170802 libvmdk-python==20181227 pycryptodome cryptography pybindgen==0.21.0 pillow pyliblzfse nska_deserialize
+RUN pip install https://github.com/libyal/libewf-legacy/releases/download/20140808/libewf-20140808.tar.gz
+RUN pip install https://github.com/ydkhatri/mac_apt/raw/master/other_dependencies/pyaff4-0.31-yk.zip
+
+WORKDIR /app
+COPY . ./
+ENTRYPOINT ["python"]


### PR DESCRIPTION
Adds a Dockerfile to simplify cross-platform setup and dependency management. I've only tested this with the SPOTLIGHT plugin though, so I'm not sure if limitations would apply.

Example usage:
```
docker run --rm -v ${PWD}:/data ghcr.io/pl4nty/mac_apt mac_apt_artifact_only.py -i /data/.store.db /data/store.db -o /data/MAC_APT_OUT -c SPOTLIGHT
```

GitHub has features to automatically build and store container images too. I'd be happy to implement those if you're interested.