### PR TITLE
Added new spotlight database paths

### DIFF
--- a/plugins/spotlight.py
+++ b/plugins/spotlight.py
@@ -18,7 +18,7 @@ from plugins.helpers.writer import *
 
 __Plugin_Name = "SPOTLIGHT"
 __Plugin_Friendly_Name = "Spotlight"
-__Plugin_Version = "1.0"
+__Plugin_Version = "1.1"
 __Plugin_Description = "Reads spotlight indexes (user, volume, iOS)"
 __Plugin_Author = "Yogesh Khatri"
 __Plugin_Author_Email = "yogesh@swiftforensics.com"


### PR DESCRIPTION
I have added the following new spotlight database paths.

```
/Users/<USER>/Library/Metadata/CoreSpotlight/NSFileProtectionComplete/index.spotlightV3/
/Users/<USER>/Library/Metadata/CoreSpotlight/NSFileProtectionCompleteUnlessOpen/index.spotlightV3/
/Users/<USER>/Library/Metadata/CoreSpotlight/NSFileProtectionCompleteUntilFirstUserAuthentication/index.spotlightV3/
/Users/<USER>/Library/Caches/com.apple.helpd/NSFileProtectionComplete/index.spotlightV3/
/Users/<USER>/Library/Caches/com.apple.helpd/NSFileProtectionCompleteUnlessOpen/index.spotlightV3/
/Users/<USER>/Library/Caches/com.apple.helpd/NSFileProtectionCompleteUntilFirstUserAuthentication/index.spotlightV3/
```
