### PR TITLE
Added feature to specify plugins not to be run

### DIFF
--- a/mac_apt.py
+++ b/mac_apt.py
@@ -518,7 +518,8 @@ else:
         plugins_to_run = plugin_name_list
         plugins_to_run.remove('ALL')
         plugins_to_run.remove('FAST')
-        plugins_not_to_run = ['IDEVICEBACKUPS', 'SPOTLIGHT', 'UNIFIEDLOGS']
+        for plugin in ('IDEVICEBACKUPS', 'SPOTLIGHT', 'UNIFIEDLOGS'):
+            plugins_not_to_run.append(plugin)
     else:
         #Check for invalid plugin names or ones not Found
         if not CheckUserEnteredPluginNames(plugins_to_run + plugins_not_to_run, plugins):


### PR DESCRIPTION
Added a feature to specify plugins not to be run (add "-" at the end of the plugin name).
For example, the following command line can run all plugins except UNIFIEDLOGS, SCREENTIME, and XPROTECTDIAG.

```
% python ./mac_apt.py -o /Volumes/4n6Data/mac_apt_out/macOS_14.3.1 -d VMDK sample.vmdk ALL UNIFIEDLOGS- SCREENTIME- XPROTECTDIAG-
```

While this method may not be the best, it has the advantage of not requiring the implementation of new options.
Also, fixed some Flake8 errors.
